### PR TITLE
Added option to edit file before the upload

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@
 function PkgcloudStorage (opts) {
   this.client = opts.client
   this.getDestination = opts.destination || getDestination
-
+  this.transformFile = opts.transform || function (originalFile, cb) {cb(originalFile)}
   function getDestination (req, file, cb) {
     cb(null, {
       container: opts.container || 'uploads',
@@ -11,28 +11,31 @@ function PkgcloudStorage (opts) {
   }
 }
 
-PkgcloudStorage.prototype._handleFile = function _handleFile (req, file, cb) {
+PkgcloudStorage.prototype._handleFile = function _handleFile (req, originalFile, cb) {
   var that = this
-
+  
+  // Apply an image transform and 
   // Change destination if needed
-  that.getDestination(req, file, function (err, dest) {
-    if (err) return cb(err)
+  this.transformFile(originalFile, function (file) {
+    that.getDestination(req, file, function (err, dest) {
+      if (err) return cb(err)
 
-    var params = {
-      container: dest.container,
-      remote: dest.remote,
-      contentType: file.mimetype
-    }
+      var params = {
+        container: dest.container,
+        remote: dest.remote,
+        contentType: file.mimetype
+      }
 
-    var outStream = that.client.upload(params)
-
-    file.stream.pipe(outStream)
-    outStream.on('error', cb)
-    outStream.on('success', function (info) {
-      cb(null, {
-        size: info.size,
-        container: params.container,
-        remote: params.remote
+      var outStream = that.client.upload(params)
+      const stream = file.stream || file
+      stream.pipe(outStream)
+      outStream.on('error', cb)
+      outStream.on('success', function (info) {
+        cb(null, {
+          size: info.size,
+          container: params.container,
+          remote: params.remote
+        })
       })
     })
   })

--- a/index.js
+++ b/index.js
@@ -27,8 +27,7 @@ PkgcloudStorage.prototype._handleFile = function _handleFile (req, originalFile,
       }
 
       var outStream = that.client.upload(params)
-      const stream = file.stream || file
-      stream.pipe(outStream)
+      file.stream.pipe(outStream)
       outStream.on('error', cb)
       outStream.on('success', function (info) {
         cb(null, {


### PR DESCRIPTION
This method permits to edit the file (resize an image for example) before upload it to the storage. 
It must return a readable stream.